### PR TITLE
Adding IAM permissions details to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Creation of the IAM user, group, and attached policy should be submitted via [CM
 
 For the IAM user needed for Github to interact with AWS (specifically ECR and ECS), the username should be `github-runner` and the user should be a part of the group `github-runner-group`. The permissions policy should be attached to that group `github-runner-group` to follow best practices.
 
+`$AWS_ACCOUNT_ID` and `$AWS_REGION` in the IAM policy should be updated to be the appropriate account ID and region for your deployment.
+
+All of the specified resources in the IAM policy do not have to exist prior to the policy being created.
+
 `github-runners` IAM policy:
 
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To be populated with more details on how to get this operationalized via ECS/Far
 
 Creation of the IAM user, group, and attached policy should be submitted via [CMS Jira](https://jiraent.cms.gov/) to the Cloud Support team.
 
-For the IAM user needed for Github to interact with AWS (specifically ECR and ECS), the username should be `github-runner` and the user should be a part of the group `github-runner-group`. The permissions policy should be attached to that group `github-runner-group` to follow best practices.
+For the IAM user needed for Github to interact with AWS (specifically ECR and ECS), the username should be `github-runner` and the user should be a part of the group `github-runner-group`. The permissions policy should be attached to that group `github-runner-group` to follow [best practices](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#use-groups-for-permissions).
 
 `$AWS_ACCOUNT_ID` and `$AWS_REGION` in the IAM policy should be updated to be the appropriate account ID and region for your deployment.
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ All of the specified resources in the IAM policy do not have to exist prior to t
 
 `github-runners` IAM policy:
 
-```
+```text
 {
     "Version": "2012-10-17",
     "Statement": [


### PR DESCRIPTION
Updating the README to include the details needed for the IAM user policy and AWS permissions so we can minimize linking out to other systems.