### PR TITLE
Generate Unique IDs for Each Runner and Add Documentation

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      DO_DEPLOY: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      DO_DEPLOY: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'push' && github.ref == 'refs/heads/generate-uniqueIDs-for-runner') }}
     steps:
       - uses: actions/checkout@v2
       - name: Create env var for docker tag

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      DO_DEPLOY: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'push' && github.ref == 'refs/heads/generate-uniqueIDs-for-runner') }}
+      DO_DEPLOY: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@v2
       - name: Create env var for docker tag

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This repository contains the Dockerfile for a self-hosted GitHub Actions runner and an associated Terraform module which can be run in your environment to provision:
 
 * An ECR repository to which you can push images of your runner
-* **(WIP)** An ECS cluster and ECS Fargate task definition to spin up an instance of this runner *per job* in your GitHub Actions workflow.
+* An ECS cluster and ECS Fargate task definition to spin up an instance of this runner *per job* in your GitHub Actions workflow.
 
 ## Set Up
 
@@ -14,10 +14,8 @@ This repository contains the Dockerfile for a self-hosted GitHub Actions runner 
     * Once you have your user, be sure to populate your repository secrets with its access keys
     * Refer to the [docs](docs) for past ADRs regarding the IAM user and GitHub actions workflow considerations. In particular, you will need to manually change your ECR repository name.
 3. Provision the Terraform module in this repository.
-4. You should now be able to push images to your ECR repository via a push to your main branch or a new release.
-
-**(WIP)**
-To be populated with more details on how to get this operationalized via ECS/Fargate.
+4. You should now be able to push images to your ECR repository via a push to your main branch or a new release. An ECS Cluster and Service should also be set up for you.
+5. See the [documentation](Usage.md) on usage of the runner on how to deploy runners to your service.
 
 ### IAM User Permissions
 

--- a/Usage.md
+++ b/Usage.md
@@ -3,18 +3,23 @@
 NEVER USE A SELF-HOSTED GITHUB RUNNER ON A PUBLIC REPOSITORY - Any individual may open a pull request against your repository and run malicious code in your runner environment.
 
 ## About
+
 As a part of your GitHub actions workflows, you may need access to internal CMS tooling that is inaccessible from GitHub's hosted runners. Using a self-hosted runner with access to the CMS network would solve this problem.
 
 ## Using the Runner
+
 This procedure assumes that you have already taken the steps documented in the main README. You have:
+
 - Requested an IAM user and verified its access requirements
 - Instantiated the requisite infrastructure in AWS ECR and ECS
 
 ### Provisioning the Runners
+
 We will use GitHub actions to provision the requisite number of runners we need we need.
 
 In the root of your repository, create a directory to house your workflow and a yml file for the workflow:
-```
+
+```sh
 mkdir -p .github/workflow
 touch .github/workflow/your-workflow.yml
 ```
@@ -25,99 +30,106 @@ Your workflow must contain the start-runner and remove-runners jobs listed below
 name: your-workflow-name
 
 on:
-	push:
-		branches: [main]
+  push:
+    branches: [main]
 
 name: sample workflow
 env:
-	AWS_REGION: us-east-1
-	ECR_REPOSITORY: github-runner
-	IMAGE_TAG: latest
-	TASK_DEFINITION_FILE: task-definition.json
-	CONTAINER_NAME: github-runner-dev-github-actions-job
-	SERVICE: github-actions-runner
-	CLUSTER: github-runner
-	DESIRED_COUNT: 3
+  AWS_REGION: us-east-1
+  ECR_REPOSITORY: github-runner
+  IMAGE_TAG: latest
+  TASK_DEFINITION_FILE: task-definition.json
+  CONTAINER_NAME: github-runner-dev-github-actions-job
+  SERVICE: github-actions-runner
+  CLUSTER: github-runner
+  DESIRED_COUNT: 3
 jobs:
-	start-runner:
-		name: Provision self-hosted runners
-		runs-on: ubuntu-latest
-		steps:
-			- uses: actions/checkout@v2
-			- name: Configure AWS credentials
-				uses: aws-actions/configure-aws-credentials@v1
-				with:
-					aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-					aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-					aws-region: ${{ env.AWS_REGION }}
-			- name: Login to Amazon ECR
-				id: login-ecr
-				uses: aws-actions/amazon-ecr-login@v1
-			- name: Create ENV variable for image
-				id: image-name
-				env:
-					ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-					ECR_REPOSITORY: ${{ env.ECR_REPOSITORY }}
-					IMAGE_TAG: ${{ env.IMAGE_TAG }}
-				run: echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
-			- name: Fill in the new image ID in the Amazon ECS task definition
-				id: task-def
-				uses: aws-actions/amazon-ecs-render-task-definition@v1
-				with:
-					task-definition: ${{ env.TASK_DEFINITION_FILE }}
-					container-name: ${{ env.CONTAINER_NAME }}
-					image: ${{ steps.image-name.outputs.image }}
-			- name: Increment ECS Service Desired Count
-				run: aws ecs update-service --service ${{ env.SERVICE }} --cluster ${{ env.CLUSTER }} --desired-count ${{ env.DESIRED_COUNT }}
-			- name: Deploy Amazon ECS task definition
-				uses: aws-actions/amazon-ecs-deploy-task-definition@v1
-				with:
-					task-definition: ${{ steps.task-def.outputs.task-definition }}
-					service: ${{ env.SERVICE }}
-					cluster: ${{ env.CLUSTER }}
-					wait-for-service-stability: true
-	## Your Jobs Here (the number of jobs you have should match the DESIRED_COUNT variable)
-	remove-runners:
-		name: Deprovision self-hosted runners
-		needs: [start-runner, YOUR_JOB_NAMES_HERE]
-	runs-on: ubuntu-latest
-	steps:
-		- name: Configure AWS credentials
-			uses: aws-actions/configure-aws-credentials@v1
-			with:
-				aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-				aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-				aws-region: ${{ env.AWS_REGION }}
-		- name: Decrement ECS Service Desired Count
-			run: aws ecs update-service --service ${{ env.SERVICE }} --cluster ${{ env.CLUSTER }} --desired-count 0
+  start-runner:
+    name: Provision self-hosted runners
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+      - name: Create ENV variable for image
+        id: image-name
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ env.ECR_REPOSITORY }}
+          IMAGE_TAG: ${{ env.IMAGE_TAG }}
+        run: echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+      - name: Fill in the new image ID in the Amazon ECS task definition
+        id: task-def
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: ${{ env.TASK_DEFINITION_FILE }}
+          container-name: ${{ env.CONTAINER_NAME }}
+          image: ${{ steps.image-name.outputs.image }}
+      - name: Increment ECS Service Desired Count
+        run: aws ecs update-service --service ${{ env.SERVICE }} --cluster ${{ env.CLUSTER }} --desired-count ${{ env.DESIRED_COUNT }}
+      - name: Deploy Amazon ECS task definition
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        with:
+          task-definition: ${{ steps.task-def.outputs.task-definition }}
+          service: ${{ env.SERVICE }}
+          cluster: ${{ env.CLUSTER }}
+          wait-for-service-stability: true
+  ## Your Jobs Here (the number of jobs you have should match the DESIRED_COUNT variable)
+  remove-runners:
+    name: Deprovision self-hosted runners
+    needs: [start-runner, YOUR_JOB_NAMES_HERE]
+  runs-on: ubuntu-latest
+  steps:
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ env.AWS_REGION }}
+    - name: Decrement ECS Service Desired Count
+      run: aws ecs update-service --service ${{ env.SERVICE }} --cluster ${{ env.CLUSTER }} --desired-count 0
 ```
 
 The items to configure are:
-1. **Your AWS Access Key and Secret Access Keys**. These should be populated in your repository secrets.
-	- You will also need to ensure that you have an IAM User with sufficient permissions to access the AWS services you will need to interact with. These are described in a separate README.
-2. All variables in the **top-level env** configuration of the workflow:
-	- AWS_REGION - your AWS region, e.g. us-east-1
-	- ECR_REPOSITORY - the name of the ECR repository in which you are housing your self-hosted runner images
-	- IMAGE_TAG - the unique tag of a specific image to pull from your ECR repository. For example, "latest", which is updated each time a new image is pushed to ECR.
-	- TASK_DEFINITION_FILE: the file name/path to a JSON-formatted task definition file. For example, if you keep a file named task-definition.json in the root of your git repo, you may simply input `task-definition.json`
-	- CONTAINER_NAME: The name of the container defined in the containerDefinitions section of the ECS task definition
-	- SERVICE: The name of the ECS service to deploy to
-	- CLUSTER: The name of the ECS service's cluster
-	- DESIRED_COUNT: The number of runners you will need. For example, if you have 3 jobs following the start-runner task, you should populate this with the value 3.
-3. **Your jobs**. Any existing workflows that you have that you wish to run on a self-hosted runner can be run by simply changing the `runs-on` argument from a GitHub hosted tag (e.g. `ubuntu-latest`) to `self-hosted`.
-4. **The `needs` variable** under the `remove-runners` job. In order to ensure that the runners are removed following the completion of the tasks and not any sooner, you must populate the list of steps that the `remove-runners` job depends on with the full list of your jobs.
-	- For example, if you have a workflow that looks like:
-		```
-		jobs:
-			start-runner:
-				...
-			job1:
-				...
-			job2:
-				...
-			job3:
-				...
-			remove-runners:
-				...
-		```
-		then your `needs` variable under `remove-runner` should be populated with `[start-runner, job1, job2, job3]`.
+
+- **Your AWS Access Key and Secret Access Keys**. These should be populated in your repository secrets.
+  - You will also need to ensure that you have an IAM User with sufficient permissions to access the AWS services you will need to interact with. These are described in a separate README.
+
+- All variables in the **top-level env** configuration of the workflow:
+
+  - AWS_REGION - your AWS region, e.g. us-east-1
+  - ECR_REPOSITORY - the name of the ECR repository in which you are housing your self-hosted runner images
+  - IMAGE_TAG - the unique tag of a specific image to pull from your ECR repository. For example, "latest", which is updated each time a new image is pushed to ECR.
+  - TASK_DEFINITION_FILE: the file name/path to a JSON-formatted task definition file. For example, if you keep a file named task-definition.json in the root of your git repo, you may simply input `task-definition.json`
+  - CONTAINER_NAME: The name of the container defined in the containerDefinitions section of the ECS task definition
+  - SERVICE: The name of the ECS service to deploy to
+  - CLUSTER: The name of the ECS service's cluster
+  - DESIRED_COUNT: The number of runners you will need. For example, if you have 3 jobs following the start-runner task, you should populate this with the value 3.
+
+- **Your jobs**. Any existing workflows that you have that you wish to run on a self-hosted runner can be run by simply changing the `runs-on` argument from a GitHub hosted tag (e.g. `ubuntu-latest`) to `self-hosted`.
+- **The `needs` variable** under the `remove-runners` job. In order to ensure that the runners are removed following the completion of the tasks and not any sooner, you must populate the list of steps that the `remove-runners` job depends on with the full list of your jobs.
+
+  - For example, if you have a workflow that looks like:
+
+    ```yaml
+    jobs:
+      start-runner:
+        ...
+      job1:
+        ...
+      job2:
+        ...
+      job3:
+        ...
+      remove-runners:
+        ...
+    ```
+
+    then your `needs` variable under `remove-runner` should be populated with `[start-runner, job1, job2, job3]`.

--- a/Usage.md
+++ b/Usage.md
@@ -1,0 +1,112 @@
+# Using a Self-Hosted GitHub Runner for your GitHub Actions Jobs
+
+NEVER USE A SELF-HOSTED GITHUB RUNNER ON A PUBLIC REPOSITORY - Any individual may open a pull request against your repository and run malicious code in your runner environment.
+
+## About
+As a part of your GitHub actions workflows, you may need access to internal CMS tooling that is inaccessible from GitHub's hosted runners. Using a self-hosted runner with access to the CMS network would solve this problem.
+
+## Using the Runner
+This procedure assumes that you have already taken the steps documented in the main README. You have:
+- Requested an IAM user and verified its access requirements
+- Instantiated the requisite infrastructure in AWS ECR and ECS
+
+### Provisioning the Runners
+Below is a sample workflow on how to provision self-hosted runners to use in your repository.
+```yaml
+on:
+	push:
+		branches: [main]
+
+name: sample workflow
+env:
+	AWS_REGION: us-east-1
+	ECR_REPOSITORY: github-runner
+	IMAGE_TAG: latest
+	TASK_DEFINITION_FILE: task-definition.json
+	CONTAINER_NAME: github-runner-dev-github-actions-job
+	SERVICE: github-actions-runner
+	CLUSTER: github-runner
+	DESIRED_COUNT: 3
+jobs:
+	start-runner:
+		name: Provision self-hosted runners
+		runs-on: ubuntu-latest
+		steps:
+			- uses: actions/checkout@v2
+			- name: Configure AWS credentials
+				uses: aws-actions/configure-aws-credentials@v1
+				with:
+					aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+					aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+					aws-region: ${{ env.AWS_REGION }}
+			- name: Login to Amazon ECR
+				id: login-ecr
+				uses: aws-actions/amazon-ecr-login@v1
+			- name: Create ENV variable for image
+				id: image-name
+				env:
+					ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+					ECR_REPOSITORY: ${{ env.ECR_REPOSITORY }}
+					IMAGE_TAG: ${{ env.IMAGE_TAG }}
+				run: echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+			- name: Fill in the new image ID in the Amazon ECS task definition
+				id: task-def
+				uses: aws-actions/amazon-ecs-render-task-definition@v1
+				with:
+					task-definition: ${{ env.TASK_DEFINITION_FILE }}
+					container-name: ${{ env.CONTAINER_NAME }}
+					image: ${{ steps.image-name.outputs.image }}
+			- name: Increment ECS Service Desired Count
+				run: aws ecs update-service --service ${{ env.SERVICE }} --cluster ${{ env.CLUSTER }} --desired-count ${{ env.DESIRED_COUNT }}
+			- name: Deploy Amazon ECS task definition
+				uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+				with:
+					task-definition: ${{ steps.task-def.outputs.task-definition }}
+					service: ${{ env.SERVICE }}
+					cluster: ${{ env.CLUSTER }}
+					wait-for-service-stability: true
+	## Your Jobs Here (the number of jobs you have should match the DESIRED_COUNT variable)
+	remove-runners:
+		name: Deprovision self-hosted runners
+		needs: [start-runner, YOUR_JOB_NAMES_HERE]
+	runs-on: ubuntu-latest
+	steps:
+		- name: Configure AWS credentials
+			uses: aws-actions/configure-aws-credentials@v1
+			with:
+				aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+				aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+				aws-region: ${{ env.AWS_REGION }}
+		- name: Decrement ECS Service Desired Count
+			run: aws ecs update-service --service ${{ env.SERVICE }} --cluster ${{ env.CLUSTER }} --desired-count 0
+```
+
+The items to configure are:
+1. **Your AWS Access Key and Secret Access Keys**. These should be populated in your repository secrets.
+	- You will also need to ensure that you have an IAM User with sufficient permissions to access the AWS services you will need to interact with. These are described in a separate README.
+2. All variables in the **top-level env** configuration of the workflow:
+	- AWS_REGION - your AWS region, e.g. us-east-1
+	- ECR_REPOSITORY - the name of the ECR repository in which you are housing your self-hosted runner images
+	- IMAGE_TAG - the unique tag of a specific image to pull from your ECR repository. For example, "latest", which is updated each time a new image is pushed to ECR.
+	- TASK_DEFINITION_FILE: the file name/path to a JSON-formatted task definition file. For example, if you keep a file named task-definition.json in the root of your git repo, you may simply input `task-definition.json`
+	- CONTAINER_NAME: The name of the container defined in the containerDefinitions section of the ECS task definition
+	- SERVICE: The name of the ECS service to deploy to
+	- CLUSTER: The name of the ECS service's cluster
+	- DESIRED_COUNT: The number of runners you will need. For example, if you have 3 jobs following the start-runner task, you should populate this with the value 3.
+3. **Your jobs**. Any existing workflows that you have that you wish to run on a self-hosted runner can be run by simply changing the `runs-on` argument from a GitHub hosted tag (e.g. `ubuntu-latest`) to `self-hosted`.
+4. **The `needs` variable** under the `remove-runners` job. In order to ensure that the runners are removed following the completion of the tasks and not any sooner, you must populate the list of steps that the `remove-runners` job depends on with the full list of your jobs.
+	- For example, if you have a workflow that looks like:
+		```
+		jobs:
+			start-runner:
+				...
+			job1:
+				...
+			job2:
+				...
+			job3:
+				...
+			remove-runners:
+				...
+		```
+		then your `needs` variable under `remove-runner` should be populated with `[start-runner, job1, job2, job3]`.

--- a/Usage.md
+++ b/Usage.md
@@ -11,8 +11,19 @@ This procedure assumes that you have already taken the steps documented in the m
 - Instantiated the requisite infrastructure in AWS ECR and ECS
 
 ### Provisioning the Runners
-Below is a sample workflow on how to provision self-hosted runners to use in your repository.
+We will use GitHub actions to provision the requisite number of runners we need we need.
+
+In the root of your repository, create a directory to house your workflow and a yml file for the workflow:
+```
+mkdir -p .github/workflow
+touch .github/workflow/your-workflow.yml
+```
+
+Your workflow must contain the start-runner and remove-runners jobs listed below.
+
 ```yaml
+name: your-workflow-name
+
 on:
 	push:
 		branches: [main]

--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ set -ex
 apt-get update
 apt-get -qq -y install --no-install-recommends \
     ca-certificates curl tar git \
-    libyaml-dev build-essential jq
+    libyaml-dev build-essential jq uuid-runtime
 
 # Install our user and create directory to install actions-runner and the hostedtoolcache
 addgroup --gid 1000 "${RUNGROUP}" && adduser --uid 1000 --ingroup "${RUNGROUP}" --shell /bin/bash "${RUNUSER}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,12 +9,14 @@ REGISTRATION_TOKEN=$(curl -s -X POST \
     -H "Authorization: token ${PERSONAL_ACCESS_TOKEN}" \
     "https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/actions/runners/registration-token" | jq -r .token)
 
+UNIQUE_ID=$(uuidgen)
+
 # Register the runner
 ./config.sh \
       --unattended \
       --url "https://github.com/${REPO_OWNER}/${REPO_NAME}" \
       --token "${REGISTRATION_TOKEN}" \
-      --name "TEST_RUNNER" \
+      --name "${UNIQUE_ID}" \
       --work ../work-dir \
       --replace
 


### PR DESCRIPTION
The main code change is just in the `build.sh` and `entrypoint.sh` to use uuidgen to create a name for each runner so that there are no naming collisions when multiple runners are provisioned.

Added a `Usage.md` file to add documentation surrounding the usage of this module. The mac-fc-infra/gha-test branch was used to test the workflow described in this documentation.

![image](https://user-images.githubusercontent.com/61299314/128738942-30badcef-4253-4a9b-b1c9-5ce31d4a89b5.png)
