### PR TITLE
Update to task-definition workflow and introducing dependabot

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+- package-ecosystem: docker
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "15:00"
+  open-pull-requests-limit: 10
+  labels:
+  - dependencies

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-    time: "15:00"
+    time: "18:00"
   open-pull-requests-limit: 10
   labels:
   - dependencies

--- a/.github/workflows/update-actions-runner.yml
+++ b/.github/workflows/update-actions-runner.yml
@@ -1,10 +1,8 @@
 name: Get latest GitHub Actions Runner
 
 on:
-  # schedule:
-  #   - cron: '40 18 * * *'
-  push:
-    branches: [update-readme-and-actions-runner]
+  schedule:
+    - cron: '40 18 * * *'
 jobs:
   update-runner:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-actions-runner.yml
+++ b/.github/workflows/update-actions-runner.yml
@@ -1,8 +1,10 @@
 name: Get latest GitHub Actions Runner
 
 on:
-  schedule:
-    - cron: '40 18 * * *'
+  # schedule:
+  #   - cron: '40 18 * * *'
+  push:
+    branches: [update-readme-and-actions-runner]
 jobs:
   update-runner:
     runs-on: ubuntu-latest
@@ -43,5 +45,7 @@ jobs:
           branch: update-actions-runner-to-${{ steps.get-versions.outputs.release_tag }}
           delete-branch: true
           title: Update Actions Runner Version to ${{ steps.get-versions.outputs.release_tag }}
-          body: Automated update from Github Actions Runner version ${{ steps.get-versions.outputs.current_tag }} to version ${{ steps.get-versions.outputs.release_tag }}
+          body: |
+            Automated update from Github Actions Runner version ${{ steps.get-versions.outputs.current_tag }} to version ${{ steps.get-versions.outputs.release_tag }}
+            Release Notes: https://github.com/actions/runner/releases/tag/v${{ steps.get-versions.outputs.release_tag }}
           team-reviewers: MAC-FC

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:18.04
 ARG RUNUSER=runner
 ARG RUNGROUP=runner
 
-ARG ACTIONS_VERSION="2.280.1"
+ARG ACTIONS_VERSION="2.279.0  "
 
 COPY build.sh /tmp
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:18.04
 ARG RUNUSER=runner
 ARG RUNGROUP=runner
 
-ARG ACTIONS_VERSION="2.279.0  "
+ARG ACTIONS_VERSION="2.280.1"
 
 COPY build.sh /tmp
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ All of the specified resources in the IAM policy do not have to exist prior to t
             "Effect": "Allow",
             "Action": [
                 "ecs:RegisterTaskDefinition",
-                "ecr:GetAuthorizationToken"
+                "ecr:GetAuthorizationToken",
+                "ecs:DescribeTaskDefinition"
             ],
             "Resource": "*"
         },
@@ -71,7 +72,6 @@ All of the specified resources in the IAM policy do not have to exist prior to t
             "Sid": "ECSClusterActions",
             "Effect": "Allow",
             "Action": [
-                "ecs:DescribeTaskDefinition",
                 "ecs:DescribeServices",
                 "ecs:UpdateService"
             ],

--- a/Usage.md
+++ b/Usage.md
@@ -38,7 +38,7 @@ env:
   AWS_REGION: us-east-1
   ECR_REPOSITORY: github-runner
   IMAGE_TAG: latest
-  CONTAINER_NAME: github-runner-dev-github-actions-job
+  CONTAINER_NAME: github-runner-dev
   SERVICE: github-actions-runner
   CLUSTER: github-runner
   DESIRED_COUNT: 3

--- a/Usage.md
+++ b/Usage.md
@@ -38,7 +38,8 @@ env:
   AWS_REGION: us-east-1
   ECR_REPOSITORY: github-runner
   IMAGE_TAG: latest
-  CONTAINER_NAME: github-runner-dev
+  CONTAINER_NAME: dev-mac-fc-infra
+  TASK_DEFINITION: github-runner-dev
   SERVICE: github-actions-runner
   CLUSTER: github-runner
   DESIRED_COUNT: 3
@@ -68,7 +69,7 @@ jobs:
         id: get-task-def
         run: |
           aws ecs describe-task-definition \
-          --task-definition ${{ env.CONTAINER_NAME }} \
+          --task-definition ${{ env.TASK_DEFINITION }} \
           --query taskDefinition > task-definition.json
       - name: Fill in the new image ID in the Amazon ECS task definition
         id: task-def
@@ -112,6 +113,7 @@ The items to configure are:
   - ECR_REPOSITORY - the name of the ECR repository in which you are housing your self-hosted runner images
   - IMAGE_TAG - the unique tag of a specific image to pull from your ECR repository. For example, "latest", which is updated each time a new image is pushed to ECR.
   - CONTAINER_NAME: The name of the container defined in the containerDefinitions section of the ECS task definition
+  - TASK_DEFINITION: The name of the task definition family to pull
   - SERVICE: The name of the ECS service to deploy to
   - CLUSTER: The name of the ECS service's cluster
   - DESIRED_COUNT: The number of runners you will need. For example, if you have 3 jobs following the start-runner task, you should populate this with the value 3.

--- a/Usage.md
+++ b/Usage.md
@@ -38,7 +38,6 @@ env:
   AWS_REGION: us-east-1
   ECR_REPOSITORY: github-runner
   IMAGE_TAG: latest
-  TASK_DEFINITION_FILE: task-definition.json
   CONTAINER_NAME: github-runner-dev-github-actions-job
   SERVICE: github-actions-runner
   CLUSTER: github-runner
@@ -65,11 +64,17 @@ jobs:
           ECR_REPOSITORY: ${{ env.ECR_REPOSITORY }}
           IMAGE_TAG: ${{ env.IMAGE_TAG }}
         run: echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+      - name: Grab task definition
+        id: get-task-def
+        run: |
+          aws ecs describe-task-definition \
+          --task-definition ${{ env.CONTAINER_NAME }} \
+          --query taskDefinition > task-definition.json
       - name: Fill in the new image ID in the Amazon ECS task definition
         id: task-def
         uses: aws-actions/amazon-ecs-render-task-definition@v1
         with:
-          task-definition: ${{ env.TASK_DEFINITION_FILE }}
+          task-definition: task-definition.json
           container-name: ${{ env.CONTAINER_NAME }}
           image: ${{ steps.image-name.outputs.image }}
       - name: Increment ECS Service Desired Count
@@ -85,29 +90,27 @@ jobs:
   remove-runners:
     name: Deprovision self-hosted runners
     needs: [start-runner, YOUR_JOB_NAMES_HERE]
-  runs-on: ubuntu-latest
-  steps:
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ env.AWS_REGION }}
-    - name: Decrement ECS Service Desired Count
-      run: aws ecs update-service --service ${{ env.SERVICE }} --cluster ${{ env.CLUSTER }} --desired-count 0
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Decrement ECS Service Desired Count
+        run: aws ecs update-service --service ${{ env.SERVICE }} --cluster ${{ env.CLUSTER }} --desired-count 0
 ```
 
 The items to configure are:
 
 - **Your AWS Access Key and Secret Access Keys**. These should be populated in your repository secrets.
-  - You will also need to ensure that you have an IAM User with sufficient permissions to access the AWS services you will need to interact with. These are described in a separate README.
 
 - All variables in the **top-level env** configuration of the workflow:
 
   - AWS_REGION - your AWS region, e.g. us-east-1
   - ECR_REPOSITORY - the name of the ECR repository in which you are housing your self-hosted runner images
   - IMAGE_TAG - the unique tag of a specific image to pull from your ECR repository. For example, "latest", which is updated each time a new image is pushed to ECR.
-  - TASK_DEFINITION_FILE: the file name/path to a JSON-formatted task definition file. For example, if you keep a file named task-definition.json in the root of your git repo, you may simply input `task-definition.json`
   - CONTAINER_NAME: The name of the container defined in the containerDefinitions section of the ECS task definition
   - SERVICE: The name of the ECS service to deploy to
   - CLUSTER: The name of the ECS service's cluster


### PR DESCRIPTION
Includes:
- Major fix to runner provisioning workflow - no longer necessary to provide a task-definition.json. Instead, use the AWS CLI tool to pull it down:
  ```
  aws ecs describe-task-definition \
            --task-definition ${{ env.TASK_DEFINITION }} \
            --query taskDefinition > task-definition.json
  ```
  We are still going to include the `amazon-ecs-render-task-definition@v1` step in the workflow so that ADOs can choose a specific image if they would like. Also reflected this change in the `Usage.md` file
- Updates to README to reflect the permissions change necessary to make the above happen. Specifically, we need `"ecs:DescribeTaskDefinition"` to be on `"Resource": "*"` instead our cluster and service
- Introduce dependabot for triggering docker image updates