### PR TITLE
Try to call out to a separate workflow that uses self-hosted runner

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -74,6 +74,14 @@ jobs:
             -u robot-mac-fc:${{ secrets.ROBOT_MAC_FC_TOKEN }} \
             https://api.github.com/repos/CMSgov/github-actions-runner-aws/actions/runners \
           | grep "online"
+      - name: Test our internal runner with call to separate workflow
+        uses: convictional/trigger-workflow-and-wait@v1.5.0
+        with:
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}
+          ref: ${{ github.ref }}
+          github_token: ${{ secrets.ROBOT_MAC_FC_TOKEN }}
+          workflow_file_name: runner-test.yml
       - name: Push docker image to Amazon ECR with all tags
         if: ${{ fromJSON(env.DO_DEPLOY) }}
         env:

--- a/.github/workflows/runner-test.yml
+++ b/.github/workflows/runner-test.yml
@@ -1,0 +1,12 @@
+name: internal runners test
+
+on:
+  workflow_dispatch
+
+jobs:
+  test_self_hosted:
+    name: Testing self-hosted tag
+    runs-on: self-hosted
+    steps:
+      - name: step 1
+        run: echo "Hello World!"


### PR DESCRIPTION
Add's in a new workflow that targets a self-hosted runner. This workflow is triggered by our main build workflow that spins up a runner in k8s/kind so we can test our runner image and make sure it will run a job successfully.