### PR TITLE
Switch to ECR with CMS Org read access

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Create env var for git sha tag
         run: echo "HASH=$(git rev-parse --short "$GITHUB_SHA")" >> "$GITHUB_ENV"
       - name: Create env var for ECR repo
-        run:  echo "ECR_REPOSITORY=github-runner" >> "$GITHUB_ENV"
+        run:  echo "ECR_REPOSITORY=github-actions-runner" >> "$GITHUB_ENV"
       - name: Configure AWS Credentials
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
This changes builds for new runner images to be stored in a central ECR that allows read access from within the CMS AWS Organization. A follow up PR will me made to remove the ECR repository definitions in this repo in favor of a more global ECR. 