### PR TITLE
Configure dependabot to update github actions versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,14 @@ updates:
   schedule:
     interval: daily
     time: "18:00"
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 2
+  labels:
+  - dependencies
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "18:00"
+  open-pull-requests-limit: 2
   labels:
   - dependencies


### PR DESCRIPTION
This should pull in PRs to update things like setup-kind and other upstream actions. I also dropped the open pull request limit to reduce dependency noise. 