### PR TITLE
Updating parameters, putting lifecycle policies in place, and adding cloudwatch logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The `entrypoint.sh` script is what sets-up the docker image to act as a runner, 
 
 ## Terraform Module
 
-This repository contains a Terraform module to deploy an ECR repo, ECS cluster, and ECS service in support of automating deployment of ephemeral self-hosted Github Actions runners within AWS.
+This repository contains a Terraform module to deploy an ECS cluster, ECS service, and log to Cloudwatch in support of automating deployment of ephemeral self-hosted Github Actions runners within AWS.
 
 This module supports the following features:
 
@@ -119,15 +119,12 @@ module "github-actions-runner-aws" {
   source = "github.com/cmsgov/github-actions-runner-aws?ref=v2.0.0"
 
   # ECS variables
-  environment               = "dev"
-  ecs_desired_count         = 0
+  environment               = "${environment}"
   ecs_vpc_id                = "${vpc.id}"
   ecs_subnet_ids            = "${vpc.private_subnets.id}"
-  logs_cloudwatch_group_arn = "${cloudwatch_group_arn.arn}"
 
   # GitHub Runner variables
   personal_access_token_arn = "${secretsmanager.token.arn}"
-  github_repo_owner         = "${repo_owner}"
   github_repo_name          = "${repo_name}"
 }
 ```
@@ -154,20 +151,20 @@ personal_access_token_arn = data.aws_secretsmanager_secret_version.token.arn
 |------|---------|
 | ci_user_arn | ARN for CI user which has read/write permissions |
 | environment | Environment name (used in naming resources) |
-| ecs_desired_count | Sets the default desired count for task definitions within the ECS service |
 | ecs_vpc_id | VPC ID to be used by ECS |
 | ecs_subnet_ids | Subnet IDs for the ECS tasks. |
 | logs_cloudwatch_group_arn | CloudWatch log group ARN for container logs |
 | personal_access_token_arn | AWS SecretsManager ARN for GitHub personal access token |
-| github_repo_owner | The name of the Github repo owner |
 | github_repo_name | The Github repository name |
 
 ### Optional Parameters
 
 | Name | Default Value | Description |
 |------|---------|---------|
+| cloudwatch_log_retention | 731 | Number of days to retain Cloudwatch logs |
 | ecr_repo_tag | "latest" | The tag to identify and pull the image in ECR repo |
 | ecs_cluster_arn | "" | ECS cluster ARN to use for running this profile |
+| ecs_desired_count | 0 | Sets the default desired count for task definitions within the ECS service |
 | github_repo_owner | "CMSgov" | The name of the Github repo owner. |
 | tags | {} | Additional tags to apply |
 

--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -1,0 +1,65 @@
+resource "aws_cloudwatch_log_group" "main" {
+  name              = "/ecs/${var.environment}/github-runner"
+  retention_in_days = var.cloudwatch_log_retention
+
+  kms_key_id = aws_kms_key.log_enc_key.arn
+
+  tags = {
+    Name        = "github-runner"
+    Environment = var.environment
+    Automation  = "Terraform"
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+}
+
+resource "aws_kms_key" "log_enc_key" {
+  description         = "KMS key for encrypting logs"
+  enable_key_rotation = true
+  policy              = data.aws_iam_policy_document.cloudwatch_logs_allow_kms.json
+
+  tags = {
+    Automation = "Terraform"
+  }
+}
+
+data "aws_iam_policy_document" "cloudwatch_logs_allow_kms" {
+  statement {
+    sid    = "Enable IAM User Permissions"
+    effect = "Allow"
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root",
+      ]
+    }
+
+    actions = [
+      "kms:*",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "Allow logs KMS access"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["logs.${data.aws_region.current.name}.amazonaws.com"]
+    }
+
+    actions = [
+      "kms:Encrypt*",
+      "kms:Decrypt*",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:Describe*"
+    ]
+    resources = ["*"]
+  }
+}

--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -67,7 +67,7 @@ data "aws_iam_policy_document" "cloudwatch_logs_allow_kms" {
       variable = "kms:EncryptionContext:aws:logs:arn"
 
       values = [
-        aws_cloudwatch_log_group.main.arn,
+        "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/ecs/${var.environment}/github-runner",
       ]
     }
   }

--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -67,7 +67,7 @@ data "aws_iam_policy_document" "cloudwatch_logs_allow_kms" {
       variable = "kms:EncryptionContext:aws:logs:arn"
 
       values = [
-        "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/ecs/${var.environment}/github-runner",
+        aws_cloudwatch_log_group.main.arn,
       ]
     }
   }

--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -61,5 +61,14 @@ data "aws_iam_policy_document" "cloudwatch_logs_allow_kms" {
       "kms:Describe*"
     ]
     resources = ["*"]
+
+    condition {
+      test     = "ArnEquals"
+      variable = "kms:EncryptionContext:aws:logs:arn"
+
+      values = [
+        "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/ecs/${var.environment}/github-runner",
+      ]
+    }
   }
 }

--- a/ecs.tf
+++ b/ecs.tf
@@ -1,5 +1,5 @@
 locals {
-  awslogs_group    = split(":", var.logs_cloudwatch_group_arn)[6]
+  awslogs_group    = split(":", aws_cloudwatch_log_group.main.arn)[6]
   cluster_arn      = var.ecs_cluster_arn != "" ? var.ecs_cluster_arn : aws_ecs_cluster.github-runner[0].arn
   cluster_provided = var.ecs_cluster_arn != "" ? true : false
 }
@@ -203,9 +203,11 @@ resource "aws_ecs_service" "actions-runner" {
     security_groups = [aws_security_group.ecs_sg.id]
   }
 
-  # github actions workflows manages changes to the task defintion, so we
-  # should ignore those changes in terraform
+  # we ignore changes to the task_definition and desired_count because
+  # github actions workflows manages changes to the task definition and
+  # scales up and down the desired count accordingly
+
   lifecycle {
-    ignore_changes = [task_definition]
+    ignore_changes = [task_definition,desired_count]
   }
 }

--- a/ecs.tf
+++ b/ecs.tf
@@ -121,7 +121,9 @@ data "aws_iam_policy_document" "task_role_policy_doc" {
       "logs:PutLogEvents",
     ]
 
-    resources = ["${var.logs_cloudwatch_group_arn}:*"]
+    resources = [
+      "${aws_cloudwatch_log_group.main.arn}:*"
+    ]
   }
 
   statement {

--- a/ecs.tf
+++ b/ecs.tf
@@ -208,6 +208,6 @@ resource "aws_ecs_service" "actions-runner" {
   # scales up and down the desired count accordingly
 
   lifecycle {
-    ignore_changes = [task_definition,desired_count]
+    ignore_changes = [task_definition, desired_count]
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -29,11 +29,6 @@ variable "ecs_subnet_ids" {
   type        = list(string)
 }
 
-variable "logs_cloudwatch_group_arn" {
-  description = "CloudWatch log group arn for container logs"
-  type        = string
-}
-
 variable "ecs_cluster_arn" {
   description = "ECS cluster ARN to use for running this profile"
   type        = string
@@ -43,12 +38,21 @@ variable "ecs_cluster_arn" {
 variable "ecs_desired_count" {
   description = "Desired task count for ECS service"
   type        = number
+  default     = 0
 }
 
 variable "tags" {
   type        = map(any)
   description = "Additional tags to apply."
   default     = {}
+}
+
+# Cloudwatch Variables
+
+variable "cloudwatch_log_retention" {
+  description = "Number of days to retain logs"
+  type        = number
+  default     = 731
 }
 
 # GitHub Runner Variables


### PR DESCRIPTION
- adds cloudwatch logs to the module itself, with the number of days for retention an optional parameter and a lifecycle policy to prevent the logs groups from being destroyed
- adds desired_count to ignore_changes lifecycle policy for ECS
- updates to documentation to more accurately reflect how the module works as well as additions being made in this PR