### PR TITLE
Address naming collision for many repos to one AWS deploy

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -44,6 +44,8 @@ jobs:
           severity: 'CRITICAL,HIGH'
       - name: Run Dockle for docker best practices
         uses: hands-lab/dockle-action@v1
+        env:
+          DOCKLE_ACCEPT_FILE_EXTENSIONS: pem
         with:
           image: '${{steps.login-ecr.outputs.registry}}/${{env.ECR_REPOSITORY}}:${{env.HASH}}'
           exit-code: '1'

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ All of the specified resources in the IAM policy do not have to exist prior to t
                 "ecs:UpdateService"
             ],
             "Resource": [
-                "arn:aws:ecs:$AWS_REGION:$AWS_ACCOUNT_ID:cluster/github-runner",
-                "arn:aws:ecs:$AWS_REGION:$AWS_ACCOUNT_ID:service/github-runner/github-actions-runner"
+                "arn:aws:ecs:$AWS_REGION:$AWS_ACCOUNT_ID:cluster/gh-runner*",
+                "arn:aws:ecs:$AWS_REGION:$AWS_ACCOUNT_ID:service/gh-runner*"
             ]
         }
     ]
@@ -163,7 +163,6 @@ personal_access_token_arn = data.aws_secretsmanager_secret_version.token.arn
 |------|---------|---------|
 | cloudwatch_log_retention | 731 | Number of days to retain Cloudwatch logs |
 | ecr_repo_tag | "latest" | The tag to identify and pull the image in ECR repo |
-| ecs_cluster_arn | "" | ECS cluster ARN to use for running this profile |
 | ecs_desired_count | 0 | Sets the default desired count for task definitions within the ECS service |
 | github_repo_owner | "CMSgov" | The name of the Github repo owner. |
 | tags | {} | Additional tags to apply |

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ personal_access_token_arn = data.aws_secretsmanager_secret_version.token.arn
 | ecs_cluster_arn | "" | ECS cluster ARN to use for running this profile |
 | ecs_desired_count | 0 | Sets the default desired count for task definitions within the ECS service |
 | github_repo_owner | "CMSgov" | The name of the Github repo owner. |
+| prevent_cloudwatch_log_destroy | true | Lifecycle policy to prevent destruction of Cloudwatch logs |
 | tags | {} | Additional tags to apply |
 
 ### Outputs

--- a/README.md
+++ b/README.md
@@ -166,7 +166,6 @@ personal_access_token_arn = data.aws_secretsmanager_secret_version.token.arn
 | ecs_cluster_arn | "" | ECS cluster ARN to use for running this profile |
 | ecs_desired_count | 0 | Sets the default desired count for task definitions within the ECS service |
 | github_repo_owner | "CMSgov" | The name of the Github repo owner. |
-| prevent_cloudwatch_log_destroy | true | Lifecycle policy to prevent destruction of Cloudwatch logs |
 | tags | {} | Additional tags to apply |
 
 ### Outputs

--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -1,17 +1,19 @@
 resource "aws_cloudwatch_log_group" "main" {
-  name              = "/ecs/${var.environment}/github-runner"
+  name              = "/ecs/${var.environment}/github-runner-${var.github_repo_owner}-${var.github_repo_name}"
   retention_in_days = var.cloudwatch_log_retention
 
   kms_key_id = aws_kms_key.log_enc_key.arn
 
   tags = {
     Name        = "github-runner"
+    GHOwner     = var.github_repo_owner
+    GHRepo      = var.github_repo_name
     Environment = var.environment
     Automation  = "Terraform"
   }
 
   lifecycle {
-    prevent_destroy = true
+    prevent_destroy = var.prevent_cloudwatch_log_destroy
   }
 
 }

--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -65,7 +65,7 @@ data "aws_iam_policy_document" "cloudwatch_logs_allow_kms" {
       variable = "kms:EncryptionContext:aws:logs:arn"
 
       values = [
-        "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/ecs/${var.environment}/github-runner",
+        "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/ecs/${var.environment}/github-runner*",
       ]
     }
   }

--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -12,10 +12,6 @@ resource "aws_cloudwatch_log_group" "main" {
     Automation  = "Terraform"
   }
 
-#  lifecycle {
-#    prevent_destroy = false
-#  }
-
 }
 
 resource "aws_kms_key" "log_enc_key" {

--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -12,9 +12,9 @@ resource "aws_cloudwatch_log_group" "main" {
     Automation  = "Terraform"
   }
 
-  lifecycle {
-    prevent_destroy = var.prevent_cloudwatch_log_destroy
-  }
+#  lifecycle {
+#    prevent_destroy = false
+#  }
 
 }
 

--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_log_group" "main" {
-  name              = "/ecs/${var.environment}/github-runner-${var.github_repo_owner}-${var.github_repo_name}"
+  name              = "/ecs/${var.environment}/gh-runner-${var.github_repo_owner}-${var.github_repo_name}"
   retention_in_days = var.cloudwatch_log_retention
 
   kms_key_id = aws_kms_key.log_enc_key.arn
@@ -65,7 +65,7 @@ data "aws_iam_policy_document" "cloudwatch_logs_allow_kms" {
       variable = "kms:EncryptionContext:aws:logs:arn"
 
       values = [
-        "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/ecs/${var.environment}/github-runner*",
+        "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/ecs/${var.environment}/gh-runner*",
       ]
     }
   }

--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_log_group" "main" {
-  name              = "/ecs/${var.environment}/gh-runner-${var.github_repo_owner}-${var.github_repo_name}"
+  name              = "/ecs/${var.environment}/gh-runner-${local.gh_name_hash}"
   retention_in_days = var.cloudwatch_log_retention
 
   kms_key_id = aws_kms_key.log_enc_key.arn

--- a/ecs.tf
+++ b/ecs.tf
@@ -1,5 +1,5 @@
 locals {
-  gh_name_hash = uuidv5("3505f3f5-f7e4-46df-a7b0-42f7472ebea5", "${var.environment}-${var.github_repo_owner}-${var.github_repo_name}")
+  gh_name_hash     = uuidv5("3505f3f5-f7e4-46df-a7b0-42f7472ebea5", "${var.environment}-${var.github_repo_owner}-${var.github_repo_name}")
   awslogs_group    = split(":", aws_cloudwatch_log_group.main.arn)[6]
   cluster_arn      = var.ecs_cluster_arn != "" ? var.ecs_cluster_arn : aws_ecs_cluster.github-runner[0].arn
   cluster_provided = var.ecs_cluster_arn != "" ? true : false

--- a/ecs.tf
+++ b/ecs.tf
@@ -1,6 +1,6 @@
 locals {
-  gh_name_hash     = uuidv5("3505f3f5-f7e4-46df-a7b0-42f7472ebea5", "${var.environment}-${var.github_repo_owner}-${var.github_repo_name}")
-  awslogs_group    = split(":", aws_cloudwatch_log_group.main.arn)[6]
+  gh_name_hash  = uuidv5("3505f3f5-f7e4-46df-a7b0-42f7472ebea5", "${var.environment}-${var.github_repo_owner}-${var.github_repo_name}")
+  awslogs_group = split(":", aws_cloudwatch_log_group.main.arn)[6]
 }
 
 data "aws_partition" "current" {}

--- a/ecs.tf
+++ b/ecs.tf
@@ -42,12 +42,12 @@ data "aws_iam_policy_document" "events_assume_role_policy" {
 # SG - ECS
 
 resource "aws_security_group" "ecs_sg" {
-  name        = "ecs-${var.environment}-${var.github_repo_owner}-${var.github_repo_name}-runner"
-  description = "${var.environment}-${var.github_repo_owner}-${var.github_repo_name}-runner container security group"
+  name        = "ecs-gh-runner-${var.environment}-${var.github_repo_owner}-${var.github_repo_name}"
+  description = "gh-runner-${var.environment}-${var.github_repo_owner}-${var.github_repo_name} container security group"
   vpc_id      = var.ecs_vpc_id
 
   tags = {
-    Name        = "ecs-${var.environment}-${var.github_repo_owner}-${var.github_repo_name}-runner"
+    Name        = "ecs-gh-runner-${var.environment}-${var.github_repo_owner}-${var.github_repo_name}"
     GHOwner     = var.github_repo_owner
     GHRepo      = var.github_repo_name
     Environment = var.environment
@@ -161,7 +161,7 @@ data "aws_iam_policy_document" "task_role_policy_doc" {
 resource "aws_ecs_cluster" "github-runner" {
   count = local.cluster_provided ? 0 : 1
 
-  name = "github-runner-${var.environment}-${var.github_repo_owner}-${var.github_repo_name}"
+  name = "gh-runner-${var.environment}-${var.github_repo_owner}-${var.github_repo_name}"
 
   tags = {
     Name        = "github-runner"
@@ -176,7 +176,7 @@ resource "aws_ecs_cluster" "github-runner" {
 }
 
 resource "aws_ecs_task_definition" "runner_def" {
-  family        = "github-runner-${var.environment}-${var.github_repo_owner}-${var.github_repo_name}"
+  family        = "gh-runner-${var.environment}-${var.github_repo_owner}-${var.github_repo_name}"
   network_mode  = "awsvpc"
   task_role_arn = aws_iam_role.task_role.arn
 
@@ -200,7 +200,7 @@ resource "aws_ecs_task_definition" "runner_def" {
 }
 
 resource "aws_ecs_service" "actions-runner" {
-  name            = "github-actions-runner-${var.environment}-${var.github_repo_owner}-${var.github_repo_name}"
+  name            = "gh-runner-${var.environment}-${var.github_repo_owner}-${var.github_repo_name}"
   cluster         = local.cluster_arn
   task_definition = aws_ecs_task_definition.runner_def.arn
   desired_count   = var.ecs_desired_count

--- a/ecs.tf
+++ b/ecs.tf
@@ -209,7 +209,7 @@ resource "aws_ecs_task_definition" "runner_def" {
 
 resource "aws_ecs_service" "actions-runner" {
   name            = "gh-runner-${local.gh_name_hash}"
-  cluster         = aws_ecs_cluster.github-runner[0].arn
+  cluster         = aws_ecs_cluster.github-runner.arn
   task_definition = aws_ecs_task_definition.runner_def.arn
   desired_count   = var.ecs_desired_count
   launch_type     = "FARGATE"

--- a/variables.tf
+++ b/variables.tf
@@ -55,6 +55,12 @@ variable "cloudwatch_log_retention" {
   default     = 731
 }
 
+variable "prevent_cloudwatch_log_destroy" {
+  description = "Lifecycle policy to prevent destruction of Cloudwatch logs"
+  type        = bool
+  default     = true
+}
+
 # GitHub Runner Variables
 
 variable "personal_access_token_arn" {

--- a/variables.tf
+++ b/variables.tf
@@ -29,12 +29,6 @@ variable "ecs_subnet_ids" {
   type        = list(string)
 }
 
-variable "ecs_cluster_arn" {
-  description = "ECS cluster ARN to use for running this profile"
-  type        = string
-  default     = ""
-}
-
 variable "ecs_desired_count" {
   description = "Desired task count for ECS service"
   type        = number

--- a/variables.tf
+++ b/variables.tf
@@ -55,12 +55,6 @@ variable "cloudwatch_log_retention" {
   default     = 731
 }
 
-variable "prevent_cloudwatch_log_destroy" {
-  description = "Lifecycle policy to prevent destruction of Cloudwatch logs"
-  type        = bool
-  default     = true
-}
-
 # GitHub Runner Variables
 
 variable "personal_access_token_arn" {


### PR DESCRIPTION
This updates the naming scheme for resources so that this module can be used for multiple repositories within the same AWS account.

This PR generates a hash using a static namespace and string constructed from Env-OrgName-RepoName. This convention was used to help eliminate possible conflicts in the future if different Github orgs have conflicting repo names (or forks) that end up being provisioned in the same AWS account, while also limiting the maximum characters in the name of an AWS resource (the limit of which varies by AWS resources). This implementation was tested in a deployment within a private repo and test AWS account.

Additionally, this PR removes the ability to pass in an existing ECS cluster and forces the creation of one using the unique naming convention outlined above. This simplifies IAM permissions requests and deployments.