### PR TITLE
Use personal token and add error handling

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -80,7 +80,7 @@ jobs:
           docker run --rm \
           -e REPO_OWNER=CMSgov \
           -e REPO_NAME=github-actions-runner-aws \
-          -e PERSONAL_ACCESS_TOKEN=${{ secrets.ROBOT_MAC_FC_TOKEN}} \
+          -e PERSONAL_ACCESS_TOKEN=${{ secrets.BHARVEY_GITHUB_TOKEN}} \
           -e RUNNER_UUID=${{ needs.set-runner-uuid.outputs.runner-uuid }} \
           ${{ env.SHA_TAG }}
 
@@ -95,7 +95,7 @@ jobs:
           until \
             curl -s \
               -H "Accept: application/vnd.github.v3+json" \
-              -u robot-mac-fc:${{ secrets.ROBOT_MAC_FC_TOKEN }} \
+              -u robot-mac-fc:${{ secrets.BHARVEY_GITHUB_TOKEN }} \
               https://api.github.com/repos/CMSgov/github-actions-runner-aws/actions/runners \
             | jq -e '.runners | .[] | select(.name == "${{ needs.set-runner-uuid.outputs.runner-uuid }}") | .status == "online"' >/dev/null
           do


### PR DESCRIPTION
Turns out that the ROBOT_MAC_FC_TOKEN set up by the Truss team is not configured in Dependabot secrets, so CI was failing for those jobs.  We don't know the login info for the old robot user, so for the time being we can use one of my personal tokens (set to expire in 30 days) while we work on getting a new robot user.

Also adds error handling for the API call to GitHub to get the token used to register runners.  I did this because I forgot to configure SSO for my PAT and the script that sets up the runners was failing without a helpful error. 

Testing: 
I ran the image locally with a valid/invalid token to test the branching logic and error messages in `entrypoint.sh`