### PR TITLE
Update `Dockerfile` to satisfy Dockle

### DIFF
--- a/.dockerfilelintrc
+++ b/.dockerfilelintrc
@@ -1,0 +1,3 @@
+rules:
+  # This is needed because Dockle checks for `rm -rf /var/lib/apt/lists` while dockerfilelint checks for `rm -rf /var/lib/apt/lists/*`. We are choosing Dockle.
+  apt-get_missing_rm: off

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update \
     jq \
     uuid-runtime \
     unzip \
-    && rm -rvf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists
 
 WORKDIR /home/runner
 USER runner


### PR DESCRIPTION
Turns out Dockle is looking for the specific string `rm -rf /var/lib/apt/lists` after you run `apt update/install`.  dockerfilelint looks for `rm -rf /var/lib/apt/lists/*` (note the wildcard 🤦) so I chose Dockle and added a config file to disable that dockerfilelint rule

Testing:  Made sure the `build and push` workflow succeeded.