### PR TITLE
Update token reference for 'Update Runner' workflow

### DIFF
--- a/.github/workflows/update-actions-runner.yml
+++ b/.github/workflows/update-actions-runner.yml
@@ -1,9 +1,6 @@
 name: Get latest GitHub Actions Runner
 
 on:
-  push:
-    branches:
-      - bharvey-fix-ci
   schedule:
     - cron: "40 18 * * *"
 jobs:

--- a/.github/workflows/update-actions-runner.yml
+++ b/.github/workflows/update-actions-runner.yml
@@ -1,6 +1,9 @@
 name: Get latest GitHub Actions Runner
 
 on:
+  push:
+    branches:
+      - bharvey-fix-ci
   schedule:
     - cron: "40 18 * * *"
 jobs:
@@ -9,8 +12,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.ROBOT_MAC_FC_TOKEN }}
 
       - name: Set release version and current version variables
         id: get-versions
@@ -31,7 +32,7 @@ jobs:
         if: ${{ steps.get-versions.outputs.release_tag != steps.get-versions.outputs.current_tag }}
         uses: peter-evans/create-pull-request@v4
         with:
-          token: ${{ secrets.ROBOT_MAC_FC_TOKEN }}
+          token: ${{ secrets.BHARVEY_GITHUB_TOKEN }}
           commit-message: Update actions runner to new version
           author: robot-mac-fc <robot-mac-fc@users.noreply.github.com>
           branch: update-actions-runner-to-${{ steps.get-versions.outputs.release_tag }}


### PR DESCRIPTION
I forgot to switch this workflow over to use my PAT when I made [this change](https://github.com/CMSgov/github-actions-runner-aws/pull/103) and deleted the robot secret. 

This reminds me that we really do need to get the new robot user set up.  I'll follow up with @yonassrobi about that.

Testing: I triggered the workflow to see that my token works and that removing the token argument to the Checkout action is OK (it is, the default `GITHUB_TOKEN` supplied to the workflow is sufficient for checking out)