### PR TITLE
Add Node CVE to .trivyignore

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -5,6 +5,7 @@ CVE-2021-3918
 CVE-2021-44906
 CVE-2022-29244
 CVE-2022-3517
+CVE-2022-24999
 
 # accept the risk of internal dotnet-core dependencies for the runner
 


### PR DESCRIPTION
We don't have a choice about this since it's internal to the GitHub runner.   I'm hopeful that once we update the runner version we can revert this. 

Testing:  Trivy succeeded after the change