### PR TITLE
Fix `grep` command

### DIFF
--- a/.github/workflows/update-actions-runner.yml
+++ b/.github/workflows/update-actions-runner.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set release version and current version variables
         id: get-versions
         run: |
-          echo ::set-output name=current_tag::$(grep ACTIONS_VERSION Dockerfile | cut -d'=' -f 2 | sed -e 's/^"//' -e 's/"$//')
+          echo ::set-output name=current_tag::$(grep "ARG ACTIONS_VERSION" Dockerfile | cut -d'=' -f 2 | sed -e 's/^"//' -e 's/"$//')
           echo ::set-output name=release_tag::$(curl -sL https://api.github.com/repos/actions/runner/releases/latest | jq -r ".tag_name[1:] | tostring")
 
       - name: Change release version in Dockerfile


### PR DESCRIPTION
The `update-actions-runner` workflow was failing to create pull releases. Turns out this is because I failed to notice when I made [this change](https://github.com/CMSgov/github-actions-runner-aws/pull/109) that it broke the `grep command` in the workflow by making it pick up all the lines with `ACTION_VERION` in them that I added to the Dockerfile.  This fixes that by making the `grep` command more specific.

Testing:  running the workflow from my feature branch created a PR successfully (I closed that PR since it didn't branch off of `main`).